### PR TITLE
Add artifactory to omnibus/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'omnibus',          git: 'https://github.com/chef/omnibus'
 gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
+gem 'artifactory'
 
 gem 'chefstyle'
 


### PR DESCRIPTION
### Description

This change only affects CI. The artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22