### PR TITLE
Upgrade to macOS 10.14

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -4,5 +4,5 @@ config: omnibus.rb
 install-dir: /opt/mac-bootstrapper
 test-path: omnibus-test.sh
 builder-to-testers-map:
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
+    - mac_os_x-10.14-x86_64


### PR DESCRIPTION
10.13 is no longer officially supported by Apple or Homebrew (which we
use here).

This should help with some recent issues we've seen in our CI/CD
pipeline, where Homebrew updates try to pull in packages that don't
work on 10.13.

Signed-off-by: Christopher Maier <cmaier@chef.io>