### PR TITLE
Remove `nexus?` and `ios_xr?` method calls

### DIFF
--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -42,8 +42,7 @@ build do
     configure_command << " --without-selinux"
   end
 
-  if nexus? || ios_xr? || s390x?
-    # ios_xr and nexus don't support posix acls
+  if s390x?
     configure_command << " --without-posix-acls"
   elsif osx?
     # lovingly borrowed from the awesome Homebrew project, thank you!


### PR DESCRIPTION
These were removed recently from Omnibus with the removal of
`chef-sugar`: https://github.com/chef/omnibus/pull/980

Signed-off-by: Christopher Maier <cmaier@chef.io>