### PR TITLE
Add project alias

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -5,6 +5,9 @@ slack:
 product_key:
   - mac-bootstrapper
 
+project:
+  alias: "mac-bootstrapper"
+
 github:
   delete_branch_on_merge: true
   version_file: "VERSION"


### PR DESCRIPTION
This allows us to promote via `/expeditor` in Slack more easily.

Before, we had to execute:

```sh
/expeditor promote habitat-sh/mac-bootstrapper:master <VERSION>
```

whereas now we can execute:

```sh
/expeditor promote mac-bootstrapper <VERSION>
```

Signed-off-by: Christopher Maier <cmaier@chef.io>