### PR TITLE
remove libiconv dependency

### DIFF
--- a/config/software/mac-bootstrapper.rb
+++ b/config/software/mac-bootstrapper.rb
@@ -5,7 +5,6 @@ license :project_license
 
 dependency "bash"
 dependency "gtar"
-dependency "libiconv"
 dependency "libsodium"
 dependency "bzip2"
 dependency "xz"


### PR DESCRIPTION
based on some testing, it does not seem like we need this dependency and it is causing problems with dynamic linking code signed hab binaries in chef-workstation. See https://github.com/chef/chef-workstation/issues/1857

Signed-off-by: Matt Wrock <matt@mattwrock.com>