### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,15 +22,13 @@ pipelines:
       env:
         - ADHOC: true
 
-
-promote:
-  channels:
+artifact_channels:
     - unstable
     - current
     - stable
 
 subscriptions:
-  - workload: pull_request_merged:{{agent_id}}:*
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
     actions:
       - built_in:bump_version:
           ignore_labels:


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

i) The promote configuration block has been deprecated for clarity. Artifact channels are relevant to things beyond promotions.
ii) The {{agent_id}} format is changing such that it is no longer a viable variable for the pull_request_* event subscriptions.